### PR TITLE
Preferring regular pip above sudo pip

### DIFF
--- a/sources/en/actdiag/introduction.rst
+++ b/sources/en/actdiag/introduction.rst
@@ -11,15 +11,17 @@ Features
 Setup
 =====
 
-Use easy_install or pip
+Install with ``pip``:
 
 .. code-block:: bash
 
-   $ sudo easy_install actdiag
+   $ pip install actdiag
 
-   Or
+Or with ``easy_install``:
 
-   $ sudo pip install actdiag
+.. code-block:: bash
+
+   $ easy_install actdiag
 
 Copy and modify ini file. example
 

--- a/sources/en/actdiag/sphinxcontrib.rst
+++ b/sources/en/actdiag/sphinxcontrib.rst
@@ -29,7 +29,7 @@ Install
 
 .. code-block:: bash
 
-   $ sudo pip install sphinxcontrib-actdiag
+   $ pip install sphinxcontrib-actdiag
 
 
 Configure Sphinx

--- a/sources/en/blockdiag/introduction.rst
+++ b/sources/en/blockdiag/introduction.rst
@@ -11,22 +11,23 @@ Features
 Setup
 =====
 
-Use easy_install or pip
+Install with ``pip``:
 
 .. code-block:: bash
 
-   $ sudo easy_install blockdiag
+   $ pip install blockdiag
 
-   Or
+Or with ``easy_install``:
 
-   $ sudo pip install blockdiag
+.. code-block:: bash
+
+   $ easy_install blockdiag
 
 If you want to export as PDF format, give pdf arguments
 
 .. code-block:: bash
 
-   $ sudo easy_install "blockdiag[pdf]"
-
+   $ easy_install "blockdiag[pdf]"
 
 Usage
 =====

--- a/sources/en/blockdiag/sphinxcontrib.rst
+++ b/sources/en/blockdiag/sphinxcontrib.rst
@@ -31,7 +31,7 @@ Install
 
 .. code-block:: bash
 
-   $ sudo pip install sphinxcontrib-blockdiag
+   $ pip install sphinxcontrib-blockdiag
 
 
 Configure Sphinx

--- a/sources/en/nwdiag/introduction.rst
+++ b/sources/en/nwdiag/introduction.rst
@@ -11,15 +11,17 @@ Features
 Setup
 =====
 
-Use easy_install or pip
+Install with ``pip``:
 
 .. code-block:: bash
 
-   $ sudo easy_install nwdiag
+   $ pip install nwdiag
 
-   Or
+Or with ``easy_install``:
 
-   $ sudo pip install nwdiag
+.. code-block:: bash
+
+   $ easy_install nwdiag
 
 Copy and modify ini file. example
 

--- a/sources/en/nwdiag/sphinxcontrib.rst
+++ b/sources/en/nwdiag/sphinxcontrib.rst
@@ -35,7 +35,7 @@ Install
 
 .. code-block:: bash
 
-   $ sudo pip install sphinxcontrib-nwdiag
+   $ pip install sphinxcontrib-nwdiag
 
 
 Configure Sphinx

--- a/sources/en/seqdiag/introduction.rst
+++ b/sources/en/seqdiag/introduction.rst
@@ -11,15 +11,17 @@ Features
 Setup
 =====
 
-Use easy_install or pip
+Install with ``pip``:
 
 .. code-block:: bash
 
-   $ sudo easy_install seqdiag
+   $ pip install seqdiag
 
-   Or
+Or with ``easy_install``:
 
-   $ sudo pip install seqdiag
+.. code-block:: bash
+
+   $ easy_install seqdiag
 
 Copy and modify ini file. example
 

--- a/sources/en/seqdiag/sphinxcontrib.rst
+++ b/sources/en/seqdiag/sphinxcontrib.rst
@@ -29,7 +29,7 @@ Install
 
 .. code-block:: bash
 
-   $ sudo pip install sphinxcontrib-seqdiag
+   $ pip install sphinxcontrib-seqdiag
 
 
 Configure Sphinx


### PR DESCRIPTION
Preferring regular `pip` above `sudo pip` for setting up, also preferring `pip` above `easy_install` (based on http://stackoverflow.com/a/30408520 arguments).
